### PR TITLE
Add package installation support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,11 +14,12 @@ Read README.md for complete project documentation including features and usage.
 
 ```
 contai/
-├── AGENTS.md        # This file - AI agent instructions
-├── README.md        # Project documentation
-├── Dockerfile       # Container definition with dev tools
-├── build.sh         # Build script with user permission handling
-└── contai           # Container runner script
+├── AGENTS.md              # This file - AI agent instructions
+├── README.md              # Project documentation
+├── Dockerfile             # Container definition with dev tools
+├── build.sh               # Build script with user permission handling
+├── contai                 # Container runner script
+└── agent-instructions.md  # Global agent instructions for end users
 ```
 
 ## Build Commands

--- a/Dockerfile
+++ b/Dockerfile
@@ -59,3 +59,8 @@ RUN npm install -g \
 	opencode-ai
 
 RUN curl -fsSL https://claude.ai/install.sh | bash
+
+RUN curl -Ls https://pkgx.sh/$(uname)/$(uname -m) -o /usr/local/bin/pkgx && \
+	chmod +x /usr/local/bin/pkgx
+
+ENV PATH="$PATH:/home/${USERNAME}/.local/bin"

--- a/Dockerfile
+++ b/Dockerfile
@@ -63,4 +63,7 @@ RUN curl -fsSL https://claude.ai/install.sh | bash
 RUN curl -Ls https://pkgx.sh/$(uname)/$(uname -m) -o /usr/local/bin/pkgx && \
 	chmod +x /usr/local/bin/pkgx
 
+RUN curl -L https://github.com/DavHau/nix-portable/releases/latest/download/nix-portable-$(uname -m) \
+	-o /usr/local/bin/nix-portable && chmod +x /usr/local/bin/nix-portable
+
 ENV PATH="$PATH:/home/${USERNAME}/.local/bin"

--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ system (i.e. normal people).
   working directory
 - **Development Tools Included**: Comes with ripgrep, bat, git, Python,
   Node.js, and other essential tools
+- **On-demand Tool Installation**: Includes [pkgx](https://pkgx.dev/) for
+  installing additional tools without root access
 - **Symlink-friendly**: Can be symlinked as different tool names (e.g.,
   `opencode` symlink runs OpenCode directly)
 
@@ -64,6 +66,53 @@ ln -s contai claude
 ```
 
 Now you can run tools directly (e.g., `opencode` instead of `contai opencode`).
+
+### Install AI Agent Instructions
+
+To enable AI agents to work best inside the container (e.g., using `pkgx` for
+missing tools instead of `apt-get`), install the provided `agent-instructions.md`
+file to the appropriate location for your AI tool:
+
+```sh
+# Create the container's home config directories
+home=~/.local/share/contai/home
+mkdir -p "$home"
+```
+
+#### OpenCode
+
+```sh
+# OpenCode
+mkdir -p "$home/.config/opencode"
+cp agent-instructions.md "$home/.config/opencode/AGENTS.md"
+```
+
+#### Claude Code
+
+```sh
+mkdir -p "$home/.claude"
+cp agent-instructions.md "$home/.claude/CLAUDE.md"
+```
+
+#### Google Gemini CLI
+
+```sh
+mkdir -p "$home/.gemini"
+cp agent-instructions.md "$home/.gemini/GEMINI.md"
+```
+
+#### OpenAI Codex CLI
+
+```sh
+mkdir -p "$home/.codex"
+cp agent-instructions.md "$home/.codex/AGENTS.md"
+```
+
+#### GitHub Copilot CLI
+
+GitHub Copilot CLI only supports project-level instructions (not global), so
+you would need to copy the file to each project's
+`.github/copilot-instructions.md`.
 
 ## Usage
 
@@ -116,8 +165,6 @@ format](https://docs.docker.com/reference/cli/docker/container/run/#env).
 - [ ] Find a way to complete OAuth flows from within the container
 - [ ] Integrate with `docker-compose` for easier multi-container setups, for
   cases where other services are needed, like MCP servers
-- [ ] Allow installing packages (add `sudo` with a config in `sudoers` that
-  allow running `apt` without password)
 - [ ] Support forwarding environment variables from the current environment.
 - [ ] Add configuration file to be able to customize, for example:
 

--- a/agent-instructions.md
+++ b/agent-instructions.md
@@ -36,10 +36,65 @@ For tools you only need once, you can run them directly without installing:
 pkgx <tool> [args...]
 ```
 
+## Fallback: nix-portable
+
+If a tool is not available via pkgx, use `nix-portable` as a fallback. It has
+access to 80,000+ packages from nixpkgs.
+
+### One-off execution with nix-portable
+
+```sh
+nix-portable nix run nixpkgs#<package> -- [args...]
+```
+
+### Examples
+
+```sh
+# Run a tool once
+nix-portable nix run nixpkgs#cowsay -- "Hello"
+
+# Run a tool with a specific attribute path
+nix-portable nix run nixpkgs#python311Packages.ipython
+```
+
+### Installing for repeated use
+
+To make a nix package available without the prefix, create a wrapper script:
+
+```sh
+# Create wrapper script in ~/.local/bin
+mkdir -p ~/.local/bin
+cat > ~/.local/bin/<tool> << 'EOF'
+#!/bin/sh
+exec nix-portable nix run nixpkgs#<package> -- "$@"
+EOF
+chmod +x ~/.local/bin/<tool>
+
+# Then use normally
+<tool> [args...]
+```
+
+### Example: Installing cowsay via nix-portable
+
+```sh
+mkdir -p ~/.local/bin
+cat > ~/.local/bin/cowsay << 'EOF'
+#!/bin/sh
+exec nix-portable nix run nixpkgs#cowsay -- "$@"
+EOF
+chmod +x ~/.local/bin/cowsay
+
+# Now use it
+cowsay "Hello from nix!"
+```
+
 ## Important
 
 - Do NOT use `apt-get`, `apt`, or other system package managers - they require
   root which is not available
+- Always try `pkgx install` first (faster, simpler)
+- Use `nix-portable` as a fallback for packages not in pkgx
 - Installed tools persist across container restarts (cached in the mounted home
   directory)
 - Check available pkgx packages at https://pkgx.dev/pkgs/
+- Search nix packages at https://search.nixos.org/packages

--- a/agent-instructions.md
+++ b/agent-instructions.md
@@ -1,0 +1,45 @@
+# Container Environment (contai)
+
+This environment runs inside a Docker container with sandboxed access. The
+container provides strong isolation but has limited pre-installed tools.
+
+## Installing Missing Tools
+
+When a command or tool is not found, use `pkgx install` to install it. This
+makes the tool available in PATH for subsequent use.
+
+```sh
+# Install a missing tool
+pkgx install <tool>
+
+# Then use it normally
+<tool> [args...]
+```
+
+### Examples
+
+```sh
+# Need ripgrep?
+pkgx install rg
+rg "pattern" .
+
+# Need a specific tool version?
+pkgx install node@20
+node --version
+```
+
+### One-off execution
+
+For tools you only need once, you can run them directly without installing:
+
+```sh
+pkgx <tool> [args...]
+```
+
+## Important
+
+- Do NOT use `apt-get`, `apt`, or other system package managers - they require
+  root which is not available
+- Installed tools persist across container restarts (cached in the mounted home
+  directory)
+- Check available pkgx packages at https://pkgx.dev/pkgs/

--- a/agent-instructions.md
+++ b/agent-instructions.md
@@ -36,18 +36,18 @@ For tools you only need once, you can run them directly without installing:
 pkgx <tool> [args...]
 ```
 
-## Fallback: nix-portable
+### Fallback: nix-portable
 
 If a tool is not available via pkgx, use `nix-portable` as a fallback. It has
 access to 80,000+ packages from nixpkgs.
 
-### One-off execution with nix-portable
+#### One-off execution with nix-portable
 
 ```sh
 nix-portable nix run nixpkgs#<package> -- [args...]
 ```
 
-### Examples
+#### Examples
 
 ```sh
 # Run a tool once
@@ -57,7 +57,7 @@ nix-portable nix run nixpkgs#cowsay -- "Hello"
 nix-portable nix run nixpkgs#python311Packages.ipython
 ```
 
-### Installing for repeated use
+#### Installing for repeated use
 
 To make a nix package available without the prefix, create a wrapper script:
 
@@ -74,7 +74,7 @@ chmod +x ~/.local/bin/<tool>
 <tool> [args...]
 ```
 
-### Example: Installing cowsay via nix-portable
+#### Example: Installing cowsay via nix-portable
 
 ```sh
 mkdir -p ~/.local/bin
@@ -88,7 +88,7 @@ chmod +x ~/.local/bin/cowsay
 cowsay "Hello from nix!"
 ```
 
-## Important
+### Important
 
 - Do NOT use `apt-get`, `apt`, or other system package managers - they require
   root which is not available

--- a/contai
+++ b/contai
@@ -20,6 +20,8 @@ docker run \
 	--rm \
 	-it \
 	--user $(id -un):$(id -gn) \
+	--cap-drop=ALL \
+	--security-opt=no-new-privileges \
 	--env-file $env_file \
 	-v "$home_dir:$HOME" \
 	-v "$PWD:$PWD" \


### PR DESCRIPTION
This PR bundles `pkgx` in the image so tools can be installed without root access, adds `nix-portable` as a fallback when `pkgx` lacks a package, and add custom agent instructions to make the agents use these tools when something is missing.

It also hardens the container a bit by removing some unneeded capabilities and permission escalation.
