### PR TITLE
Add support for the Apple container runtime

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.build-stamp-*

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,6 +28,9 @@ contai/
 |--------------|----------------------------------------------------------|
 | `./build.sh` | Builds Docker image tagged as `contai:latest`            |
 | `./contai`   | Runs the container with current directory mounted        |
+| `make image` | Build the Docker image (via Makefile)                    |
+| `make install` | Install contai to `~/.local/bin` (or custom `PREFIX`)  |
+| `make clean` | Remove the Docker image and build stamp                  |
 
 ### Building the Container
 
@@ -36,6 +39,17 @@ contai/
 ```
 
 The build script passes host UID/GID to ensure proper file permissions inside the container.
+
+### Installing with Makefile
+
+```sh
+make install                    # Install to ~/.local/bin (builds image if needed)
+make install PREFIX=/usr/local # Install to /usr/local/bin
+sudo make install PREFIX=/usr/local # Install as root (requires pre-built image)
+METHOD=link make install        # Symlink instead of copy
+```
+
+Note: Running `make install` as root requires the image to be built first (run `make image` as non-root).
 
 ### Running the Container
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ ARG GID
 ARG GROUPNAME
 
 RUN userdel --force --remove ubuntu && \
-	groupadd --gid ${GID} ${GROUPNAME} && \
+	(getent group ${GID} || groupadd --gid ${GID} ${GROUPNAME}) && \
 	useradd --create-home --shell /bin/bash --gid ${GID} --uid ${UID} ${USERNAME}
 
 RUN apt-get update && apt-get install -y \

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,81 @@
+.PHONY: image clean help install
+
+# Installation prefix (default: ~/.local)
+PREFIX ?= $(HOME)/.local
+# Installation method: 'copy' or 'link' (symlink)
+METHOD ?= copy
+# Detect container runtime (Apple container or Docker)
+RUNTIME ?= $(shell command -v container >/dev/null 2>&1 \
+	&& echo container || echo docker)
+# Stampfile name includes runtime so switching runtimes triggers a rebuild
+STAMPFILE = .build-stamp-$(RUNTIME)
+
+# Build the image using build.sh. The stampfile tracks when the image was last
+# built, allowing make to skip rebuilding if Dockerfile and build.sh haven't
+# changed.
+image: $(STAMPFILE)
+
+$(STAMPFILE): Dockerfile build.sh
+	./build.sh
+	touch $(STAMPFILE)
+
+# Install contai to $(PREFIX)/bin. Creates symlinks for each AI tool so they
+# can be invoked directly (e.g., 'opencode' instead of 'contai opencode').
+install: contai
+# Running as root requires pre-built image (can't build as root)
+ifeq ($(shell id -u),0)
+	@if [ ! -f .build-stamp-* ]; then \
+		echo "Error: Image not built. Run 'make image' as non-root" \
+			"first." >&2; \
+		exit 1; \
+	fi
+else
+	$(MAKE) image
+endif
+	mkdir -p $(PREFIX)/bin
+ifeq ($(METHOD),copy)
+	cp contai $(PREFIX)/bin/
+else ifeq ($(METHOD),link)
+	ln -sf $(CURDIR)/contai $(PREFIX)/bin/contai
+else
+	$(error METHOD must be 'copy' or 'link', got '$(METHOD)')
+endif
+# Create symlinks for each AI tool (contai uses basename to detect tool)
+	ln -sf $(PREFIX)/bin/contai $(PREFIX)/bin/opencode
+	ln -sf $(PREFIX)/bin/contai $(PREFIX)/bin/copilot
+	ln -sf $(PREFIX)/bin/contai $(PREFIX)/bin/codex
+	ln -sf $(PREFIX)/bin/contai $(PREFIX)/bin/gemini
+	ln -sf $(PREFIX)/bin/contai $(PREFIX)/bin/claude
+
+# Remove all images and stampfiles (full clean)
+# Extract runtime name from stampfile \
+# container uses 'image delete', docker uses 'rmi'
+clean:
+	@for stamp in .build-stamp-*; do \
+		if [ -f "$$stamp" ]; then \
+			runtime=$${stamp#.build-stamp-}; \
+			if [ "$$runtime" = "container" ]; then \
+				$$runtime image delete contai:latest 2>/dev/null \
+					|| true; \
+			else \
+				$$runtime rmi contai:latest 2>/dev/null || true; \
+			fi; \
+			rm -f "$$stamp"; \
+		fi; \
+	done
+
+help:
+	@echo "Usage: make [target]"
+	@echo ""
+	@echo "Targets:"
+	@echo "  image   Build the Docker image"
+	@echo "  install Install contai (builds image if needed, errors if"
+	@echo "          run as root without image)"
+	@echo "  clean   Remove all images and stampfiles"
+	@echo "  help    Show this help message"
+	@echo ""
+	@echo "Variables:"
+	@echo "  PREFIX  Installation prefix (default: ~/.local)"
+	@echo "  METHOD  Installation method: 'copy' (default) or 'link'"
+	@echo "  RUNTIME Container runtime: 'docker' or 'container'"
+	@echo "          (default: auto-detect)"

--- a/README.md
+++ b/README.md
@@ -25,6 +25,10 @@ system (i.e. normal people).
   installing additional tools without root access
 - **Symlink-friendly**: Can be symlinked as different tool names (e.g.,
   `opencode` symlink runs OpenCode directly)
+- **Apple Container Runtime**: Supports Apple's new `container` runtime with
+  automatic detection, falling back to Docker
+- **Timezone Passthrough**: Automatically detects and passes your host timezone
+  to the container for correct git commit timestamps
 
 ## Build
 
@@ -37,7 +41,50 @@ To build the container image:
 This will create a Docker image tagged as `contai:latest` with your host user's
 UID/GID for proper file permissions.
 
+The build script automatically detects Apple's `container` runtime if available,
+falling back to Docker. You can override the runtime with the `RUNTIME` environment
+variable:
+
+```sh
+RUNTIME=docker ./build.sh
+```
+
 ## Installation
+
+### Using Makefile (Recommended)
+
+The easiest way to install `contai` is using the provided Makefile:
+
+```sh
+make install                    # Install to ~/.local/bin
+sudo make install PREFIX=/usr/local  # Install system-wide
+                                     # (requires "make image" step separately)
+```
+
+The Makefile will:
+- Build the image if needed (unless running as root)
+- Copy `contai` to `$(PREFIX)/bin`
+- Create symlinks for each AI tool (`opencode`, `copilot`, `codex`, `gemini`, `claude`)
+
+To install via symlink instead of copy:
+
+```sh
+METHOD=link make install
+```
+
+**Note**: The symlink method is useful for development, as changes to `contai` in
+your source tree take effect immediately without reinstalling. Not recommended
+for system-wide installations as the source directory becomes a trusted path.
+
+Other useful targets:
+
+```sh
+make image  # Build the Docker image
+make clean  # Remove the image and build stamp
+make help   # Show available targets
+```
+
+### Manual Installation
 
 After building, you can install `contai` to your PATH:
 
@@ -139,6 +186,15 @@ You can define environment variables in the container by writing to a
 `~/.local/share/contai/env.list` file. The file is expected to have the
 standard [docker `--env-file`
 format](https://docs.docker.com/reference/cli/docker/container/run/#env).
+
+### Runtime Variables
+
+The following environment variables control the container runtime:
+
+- `RUNTIME`: Override the container runtime (`docker` or `container`). By default,
+  the script auto-detects Apple's `container` runtime, falling back to Docker.
+- `TZ`: Override the timezone passed to the container. By default, the script
+  detects the host timezone from `/etc/localtime`.
 
 ## Known Issues
 

--- a/build.sh
+++ b/build.sh
@@ -1,11 +1,25 @@
 #!/bin/sh
 set -eu
 
-docker build \
-	-t contai:latest \
-	--build-arg UID=$(id -u) \
-	--build-arg USERNAME=$(id -un) \
-	--build-arg GID=$(id -g) \
-	--build-arg GROUPNAME=$(id -gn) \
-	"$@" \
-	- < Dockerfile
+runtime=docker
+command -v container >/dev/null 2>&1 && runtime=container
+
+if test "$runtime" = "docker"; then
+	$runtime build \
+		-t contai:latest \
+		--build-arg UID="$(id -u)" \
+		--build-arg USERNAME="$(id -un)" \
+		--build-arg GID="$(id -g)" \
+		--build-arg GROUPNAME="$(id -gn)" \
+		"$@" \
+		- <Dockerfile
+else
+	$runtime --debug build \
+		-t contai:latest \
+		--build-arg UID="$(id -u)" \
+		--build-arg USERNAME="$(id -un)" \
+		--build-arg GID="$(id -g)" \
+		--build-arg GROUPNAME="$(id -gn)" \
+		"$@" \
+		.
+fi

--- a/build.sh
+++ b/build.sh
@@ -1,11 +1,14 @@
 #!/bin/sh
 set -eu
 
-runtime=docker
-command -v container >/dev/null 2>&1 && runtime=container
+# Use RUNTIME from environment if set, otherwise auto-detect
+if test -z "${RUNTIME:-}"; then
+	RUNTIME=docker
+	command -v container >/dev/null 2>&1 && RUNTIME=container
+fi
 
-if test "$runtime" = "docker"; then
-	$runtime build \
+if test "$RUNTIME" = "docker"; then
+	$RUNTIME build \
 		-t contai:latest \
 		--build-arg UID="$(id -u)" \
 		--build-arg USERNAME="$(id -un)" \
@@ -14,7 +17,7 @@ if test "$runtime" = "docker"; then
 		"$@" \
 		- <Dockerfile
 else
-	$runtime --debug build \
+	$RUNTIME --debug build \
 		-t contai:latest \
 		--build-arg UID="$(id -u)" \
 		--build-arg USERNAME="$(id -un)" \

--- a/contai
+++ b/contai
@@ -31,6 +31,12 @@ then
 	security_opts="--cap-drop=ALL --security-opt=no-new-privileges"
 fi
 
+if ! $runtime image inspect contai:latest >/dev/null 2>&1
+then
+	echo "Error: Image 'contai:latest' not found. Run './build.sh' first." >&2
+	exit 1
+fi
+
 # shellcheck disable=SC2086
 $runtime run \
 	--rm \

--- a/contai
+++ b/contai
@@ -9,7 +9,10 @@ then
 fi
 
 tool=$(basename "$0")
-
+# TODO do we want to whitelist $tool to prevent the container from being
+# run maliciously with arbitrary commands. Maybe with an exception for
+# development/debugging?
+#
 # When called as 'contai', use first arg as tool name and shift it out.
 # This allows 'contai opencode --version' to pass '--version' to opencode.
 if test "$tool" = "contai"

--- a/contai
+++ b/contai
@@ -1,6 +1,9 @@
 #!/bin/sh
 set -eu
 
+runtime=docker
+command -v container >/dev/null 2>&1 && runtime=container
+
 tool=$(basename "$0")
 
 if test "$tool" = "contai"
@@ -9,21 +12,27 @@ then
 fi
 
 data_dir=~/.local/share/contai
-
 home_dir=$data_dir/home
 env_file="$data_dir/env.list"
+container_home="/home/$(id -un)"
 
 mkdir -p "$home_dir"
 touch "$env_file"
 
-docker run \
+security_opts=
+if test "$runtime" = "docker"
+then
+	security_opts="--cap-drop=ALL --security-opt=no-new-privileges"
+fi
+
+# shellcheck disable=SC2086
+$runtime run \
 	--rm \
 	-it \
-	--user $(id -un):$(id -gn) \
-	--cap-drop=ALL \
-	--security-opt=no-new-privileges \
-	--env-file $env_file \
-	-v "$home_dir:$HOME" \
+	--user "$(id -un):$(id -gn)" \
+	$security_opts \
+	--env-file "$env_file" \
+	-v "$home_dir:$container_home" \
 	-v "$PWD:$PWD" \
 	-w "$PWD" \
 	contai:latest \

--- a/contai
+++ b/contai
@@ -29,6 +29,12 @@ container_home="/home/$(id -un)"
 mkdir -p "$home_dir"
 touch "$env_file"
 
+# Detect host timezone
+if test -z "${TZ:-}"
+then
+	TZ=$(readlink /etc/localtime 2>/dev/null | sed 's|.*/zoneinfo/||') || true
+fi
+
 security_opts=
 if test "$RUNTIME" = "docker"
 then
@@ -41,6 +47,13 @@ then
 	exit 1
 fi
 
+tz_opt=
+if test -n "${TZ:-}"
+then
+	# especially important for git commits
+	tz_opt="-e TZ=$TZ"
+fi
+
 # shellcheck disable=SC2086
 $RUNTIME run \
 	--rm \
@@ -51,6 +64,7 @@ $RUNTIME run \
 	-v "$home_dir:$container_home" \
 	-v "$PWD:$PWD" \
 	-w "$PWD" \
+	$tz_opt \
 	contai:latest \
 	$tool \
 	"$@"

--- a/contai
+++ b/contai
@@ -6,9 +6,15 @@ command -v container >/dev/null 2>&1 && runtime=container
 
 tool=$(basename "$0")
 
+# When called as 'contai', use first arg as tool name and shift it out.
+# This allows 'contai opencode --version' to pass '--version' to opencode.
 if test "$tool" = "contai"
 then
-	tool=
+	tool=${1:-}
+	if test -n "$tool"
+	then
+		shift
+	fi
 fi
 
 data_dir=~/.local/share/contai

--- a/contai
+++ b/contai
@@ -1,8 +1,12 @@
 #!/bin/sh
 set -eu
 
-runtime=docker
-command -v container >/dev/null 2>&1 && runtime=container
+# Use RUNTIME from environment if set, otherwise auto-detect
+if test -z "${RUNTIME:-}"
+then
+	RUNTIME=docker
+	command -v container >/dev/null 2>&1 && RUNTIME=container
+fi
 
 tool=$(basename "$0")
 
@@ -26,19 +30,19 @@ mkdir -p "$home_dir"
 touch "$env_file"
 
 security_opts=
-if test "$runtime" = "docker"
+if test "$RUNTIME" = "docker"
 then
 	security_opts="--cap-drop=ALL --security-opt=no-new-privileges"
 fi
 
-if ! $runtime image inspect contai:latest >/dev/null 2>&1
+if ! $RUNTIME image inspect contai:latest >/dev/null 2>&1
 then
 	echo "Error: Image 'contai:latest' not found. Run './build.sh' first." >&2
 	exit 1
 fi
 
 # shellcheck disable=SC2086
-$runtime run \
+$RUNTIME run \
 	--rm \
 	-it \
 	--user "$(id -un):$(id -gn)" \


### PR DESCRIPTION
## Summary

I added support for Apple's new Container Runtime, a Makefile for easier installation, and timezone passthrough so your git commits show the correct time.

## What I Changed

- **Apple Container Runtime**: The scripts now auto-detect Apple's `container` CLI and use it instead of Docker when it's available. You can override this with `RUNTIME=docker` or `RUNTIME=container` if you want.
- **Makefile**: I added a Makefile so you can just run `make install` instead of manually copying files around. There's also a `METHOD=link` option that's useful when you're developing - changes to `contai` take effect immediately without reinstalling.
- **Timezone passthrough**: I added code to detect your host timezone from `/etc/localtime` and pass it to the container. This means your git commits will show the right time instead of UTC.
- **Misc fixes**: The Dockerfile now handles the case where the group already exists, and I only apply the extra security flags when using Docker (Apple's runtime has its own security model).

## How to Test

```sh
# on macOS be sure that container is installed via homebrew
./build.sh
./contai opencode --version # Uses whatever runtime is available
RUNTIME=docker ./contai opencode --version # Force Docker
```

## Misc

- I also tested with `docker` via Colima (headless docker on macOS)
- I only tested with opencode, not claude or any of the others
- **NOTE**: I'm seeing some opencode database corruption. I don't know if this is an opencode bug, something to do with containers, a combination of the two, or something else.
	- There is a github issue related to db corruption: <https://github.com/anomalyco/opencode/issues/14970>
	- I've added a function to my local branch that makes a backup of the database and automatically gets called before starting the container
- More info on the Apple container runtime:
	- <https://github.com/apple/container>
